### PR TITLE
download enhanced

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "dark-toggle": "^2.0.0",
+    "file-saver": "^2.0.5",
     "html-to-image": "^1.11.11",
     "i18next": "^24.0.0",
     "lodash-es": "^4.17.21",
@@ -53,6 +54,7 @@
   },
   "devDependencies": {
     "@iconify/types": "^2.0.0",
+    "@types/file-saver": "^2.0.7",
     "@types/lodash-es": "^4.17.12",
     "@types/node": "^20",
     "@types/react": "^18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       dark-toggle:
         specifier: ^2.0.0
         version: 2.0.0
+      file-saver:
+        specifier: ^2.0.5
+        version: 2.0.5
       html-to-image:
         specifier: ^1.11.11
         version: 1.11.11
@@ -117,6 +120,9 @@ importers:
       '@iconify/types':
         specifier: ^2.0.0
         version: 2.0.0
+      '@types/file-saver':
+        specifier: ^2.0.7
+        version: 2.0.7
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
@@ -1057,46 +1063,55 @@ packages:
     resolution: {integrity: sha512-9OwUnK/xKw6DyRlgx8UizeqRFOfi9mf5TYCw1uolDaJSbUmBxP85DE6T4ouCMoN6pXw8ZoTeZCSEfSaYo+/s1w==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.27.4':
     resolution: {integrity: sha512-Vgdo4fpuphS9V24WOV+KwkCVJ72u7idTgQaBoLRD0UxBAWTF9GWurJO9YD9yh00BzbkhpeXtm6na+MvJU7Z73A==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.27.4':
     resolution: {integrity: sha512-pleyNgyd1kkBkw2kOqlBx+0atfIIkkExOTiifoODo6qKDSpnc6WzUY5RhHdmTdIJXBdSnh6JknnYTtmQyobrVg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.27.4':
     resolution: {integrity: sha512-caluiUXvUuVyCHr5DxL8ohaaFFzPGmgmMvwmqAITMpV/Q+tPoaHZ/PWa3t8B2WyoRcIIuu1hkaW5KkeTDNSnMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.27.4':
     resolution: {integrity: sha512-FScrpHrO60hARyHh7s1zHE97u0KlT/RECzCKAdmI+LEoC1eDh/RDji9JgFqyO+wPDb86Oa/sXkily1+oi4FzJQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.27.4':
     resolution: {integrity: sha512-qyyprhyGb7+RBfMPeww9FlHwKkCXdKHeGgSqmIXw9VSUtvyFZ6WZRtnxgbuz76FK7LyoN8t/eINRbPUcvXB5fw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.27.4':
     resolution: {integrity: sha512-PFz+y2kb6tbh7m3A7nA9++eInGcDVZUACulf/KzDtovvdTizHpZaJty7Gp0lFwSQcrnebHOqxF1MaKZd7psVRg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.27.4':
     resolution: {integrity: sha512-Ni8mMtfo+o/G7DVtweXXV/Ol2TFf63KYjTtoZ5f078AUgJTmaIJnj4JFU7TK/9SVWTaSJGxPi5zMDgK4w+Ez7Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.27.4':
     resolution: {integrity: sha512-5AeeAF1PB9TUzD+3cROzFTnAJAcVUGLuR8ng0E0WXGkYhp6RD6L+6szYVX+64Rs0r72019KHZS1ka1q+zU/wUw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.27.4':
     resolution: {integrity: sha512-yOpVsA4K5qVwu2CaS3hHxluWIK5HQTjNV4tWjQXluMiiiu4pJj4BN98CvxohNCpcjMeTXk/ZMJBRbgRg8HBB6A==}
@@ -1139,24 +1154,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.9.3':
     resolution: {integrity: sha512-tzVH480RY6RbMl/QRgh5HK3zn1ZTFsThuxDGo6Iuk1MdwIbdFYUY034heWUTI4u3Db97ArKh0hNL0xhO3+PZdg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.9.3':
     resolution: {integrity: sha512-ivXXBRDXDc9k4cdv10R21ccBmGebVOwKXT/UdH1PhxUn9m/h8erAWjz5pcELwjiMf27WokqPgaWVfaclDbgE+w==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.9.3':
     resolution: {integrity: sha512-ILsGMgfnOz1HwdDz+ZgEuomIwkP1PHT6maigZxaCIuC6OPEhKE8uYna22uU63XvYcLQvZYDzpR3ms47WQPuNEg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.9.3':
     resolution: {integrity: sha512-e+XmltDVIHieUnNJHtspn6B+PCcFOMYXNJB1GqoCcyinkEIQNwC8KtWgMqUucUbEWJkPc35NHy9k8aCXRmw9Kg==}
@@ -1213,6 +1232,9 @@ packages:
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
+
+  '@types/file-saver@2.0.7':
+    resolution: {integrity: sha512-dNKVfHd/jk0SkR/exKGj2ggkB45MAkzvWCaqLUUgkyjITkGNzH8H+yUwr+BLJUBjZOe9w8X3wgmXhZDRg1ED6A==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -2057,6 +2079,9 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  file-saver@2.0.5:
+    resolution: {integrity: sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -4160,6 +4185,8 @@ snapshots:
 
   '@types/estree@1.0.6': {}
 
+  '@types/file-saver@2.0.7': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -5285,6 +5312,8 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  file-saver@2.0.5: {}
 
   fill-range@7.1.1:
     dependencies:

--- a/src/components/download-button/index.tsx
+++ b/src/components/download-button/index.tsx
@@ -1,26 +1,54 @@
 import { DownloadIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { DownloadTypes } from '@/store/constants'
+
 import { Button } from '../ui/button'
 
 interface DownloadButtonProps {
-  onClick: () => void
+  onClick: (downloadType: DownloadTypes) => void
 }
 
 export const DownloadButton = (props: DownloadButtonProps) => {
   const { onClick } = props
   const { t } = useTranslation()
   return (
-    <Button
-      className='shrink-0'
-      size='lg'
-      onClick={(e) => {
-        e.stopPropagation()
-        onClick()
-      }}
-    >
-      <DownloadIcon />
-      {t('download')}
-    </Button>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button className='shrink-0' size='lg'>
+          <DownloadIcon />
+          {t('download')}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        {[DownloadTypes.Png, DownloadTypes.Svg, DownloadTypes.Jpeg].map(
+          (type) => (
+            <DropdownMenuItem
+              key={type}
+              onClick={(e) => {
+                e.stopPropagation()
+                onClick(type)
+              }}
+            >
+              {type}
+            </DropdownMenuItem>
+          ),
+        )}
+        <DropdownMenuItem
+          onClick={(e) => {
+            e.stopPropagation()
+            onClick(DownloadTypes.InnerSvg)
+          }}
+        >
+          {t('inner svg')}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }

--- a/src/components/preview-icon-dialog/index.tsx
+++ b/src/components/preview-icon-dialog/index.tsx
@@ -103,10 +103,11 @@ export const PreviewDialog = () => {
                 </Button>
               )}
               <DownloadButton
-                onClick={() => {
+                onClick={(downloadType) => {
                   downloadImage(
                     imageSize,
-                    `${previewIcon.name}.png`,
+                    previewIcon.name,
+                    downloadType,
                     iconCardRef.current,
                   )
                 }}

--- a/src/components/preview-text/index.tsx
+++ b/src/components/preview-text/index.tsx
@@ -18,8 +18,8 @@ export const PreviewText = () => {
       <Separator />
       <IconCard ref={iconCardRef} inPreview previewType='text' />
       <DownloadButton
-        onClick={() => {
-          downloadImage(imageSize, `text.png`, iconCardRef.current)
+        onClick={(downloadType) => {
+          downloadImage(imageSize, 'text', downloadType, iconCardRef.current)
         }}
       />
     </PreviewContainer>

--- a/src/components/preview-upload/index.tsx
+++ b/src/components/preview-upload/index.tsx
@@ -65,8 +65,8 @@ export const PreviewUpload = () => {
         onChange={handleFileUpload}
       />
       <DownloadButton
-        onClick={() => {
-          downloadImage(imageSize, `upload.png`, iconCardRef.current)
+        onClick={(downloadType) => {
+          downloadImage(imageSize, 'upload', downloadType, iconCardRef.current)
         }}
       />
     </PreviewContainer>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -12,6 +12,7 @@ export const en = {
     'icon shadow settings': 'Icon Shadow Settings',
     'import and export': 'Preset Import and Export',
     'import data': 'Import Presets',
+    'inner svg': 'Inner Svg',
     'inset shadow settings': 'Inset Shadow Settings',
     'shadow settings': 'Shadow Settings',
     'text settings': 'Text Settings',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -12,6 +12,7 @@ export const zh = {
     'icon shadow settings': '图标阴影设置',
     'import and export': '预设导入与导出',
     'import data': '导入预设',
+    'inner svg': '内部Svg',
     'inset shadow settings': '内阴影设置',
     'shadow settings': '阴影设置',
     'text settings': '文字设置',

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,9 +1,10 @@
 import { clsx, type ClassValue } from 'clsx'
-import { toPng } from 'html-to-image'
+import { saveAs } from 'file-saver'
+import { toJpeg, toPng, toSvg } from 'html-to-image'
 import { nanoid } from 'nanoid'
 import { twMerge } from 'tailwind-merge'
 
-import { Gradient } from '@/store/constants'
+import { DownloadTypes, Gradient } from '@/store/constants'
 
 import type { APIv2CollectionResponse } from '@/services/iconify'
 import type { Color, Perspective, Shadow } from '@/store/interface'
@@ -166,19 +167,51 @@ export const scaleShadow = (shadow: Shadow, scale: number) => {
 export const downloadImage = (
   imageSize: number,
   fileName: string,
+  fileType: DownloadTypes,
   element?: HTMLElement | null,
 ) => {
   if (element) {
-    toPng(element, {
-      canvasHeight: imageSize,
-      canvasWidth: imageSize,
-      pixelRatio: 1,
-    }).then((dataUrl) => {
+    const downloadAction = (dataUrl: string, fileExtension: string) => {
       const a = document.createElement('a')
       a.href = dataUrl
-      a.download = fileName
+      a.download = `${fileName}.${fileExtension}`
       a.click()
-    })
+    }
+    switch (fileType) {
+      case DownloadTypes.Png:
+        toPng(element, {
+          canvasHeight: imageSize,
+          canvasWidth: imageSize,
+          pixelRatio: 1,
+        }).then((dataUrl) => downloadAction(dataUrl, 'png'))
+        break
+      case DownloadTypes.Svg:
+        toSvg(element, {
+          canvasHeight: imageSize,
+          canvasWidth: imageSize,
+          pixelRatio: 1,
+        }).then((dataUrl) => downloadAction(dataUrl, 'svg'))
+        break
+      case DownloadTypes.Jpeg:
+        toJpeg(element, {
+          canvasHeight: imageSize,
+          canvasWidth: imageSize,
+          pixelRatio: 1,
+          quality: 0.95,
+        }).then((dataUrl) => downloadAction(dataUrl, 'jpeg'))
+        break
+      case DownloadTypes.InnerSvg:
+        {
+          const svgElement = element.querySelector('svg')
+          if (svgElement) {
+            const blob = new Blob([svgElement.outerHTML], {
+              type: 'image/svg+xml',
+            })
+            saveAs(blob, `${fileName}.svg`)
+          }
+        }
+        break
+    }
   }
 }
 

--- a/src/store/constants.ts
+++ b/src/store/constants.ts
@@ -25,3 +25,11 @@ export const enum Gradient {
   Radial = 'radial',
   Conic = 'conic',
 }
+
+// eslint-disable-next-line no-restricted-syntax
+export const enum DownloadTypes {
+  Png = 'Png',
+  Svg = 'Svg',
+  Jpeg = 'Jpeg',
+  InnerSvg = 'Inner-Svg',
+}


### PR DESCRIPTION
#45 
support for selecting image type when download
support for downloading inner svg(not the original svg from Iconify, but icon settings applied)

It is useful for downloading inner svg when you need the effects(such as animation) of the original svg.

click the download button, will show DropdownMenu as following
![微信截图_20250709164033](https://github.com/user-attachments/assets/4e664a64-52a7-45bf-bed4-0a67612cc07d)
![微信截图_20250709164145](https://github.com/user-attachments/assets/3ad5b57f-c386-4b40-953a-e3485369bc9c)
